### PR TITLE
Support for digest authentication for locks. Added missing const fs.

### DIFF
--- a/lib/lock-accessory.js
+++ b/lib/lock-accessory.js
@@ -2,6 +2,7 @@
 
 const request = require('request');
 const url = require('url');
+const fs = require('fs');
 
 let Accessory, Service, Characteristic;
 
@@ -60,7 +61,8 @@ LockAccessory.prototype.setLockState = function(targetState, callback) {
   var options = {
     'auth': {
       'username': this.username,
-      'password': this.password
+      'password': this.password,
+      'sendImmediately': false
     },
     cert: this.sslOptions.cert,
     key: this.sslOptions.key,


### PR DESCRIPTION
This code errored out as is without const fs, so I added that. I've also made this work with HTTP Digest Auth by setting 'sendImmediately': false.